### PR TITLE
More flexibility for single URL captures

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,16 +55,23 @@ function capture(urls, options, callback) {
 
       var urlParts = urlUtil.parse(url, true),
           filename = urlParts.pathname,
-          auth = urlParts.auth;
+          auth = urlParts.auth,
+          filePath;
+          
+      // The outPath is a file, so don't generate the URLs automatically
+      if ([".pdf", ".jpg", ".png", ".gif"].indexOf(outPath.substr(-4)) !== -1) {
+        filePath = outPath;
+      } else {
+        if (S(filename).endsWith("/")) filename += "index"; // Append
 
-      if (S(filename).endsWith("/")) filename += "index"; // Append
+        filePath = path.resolve(
+                    process.cwd(),
+                    outPath,
+                    S(urlParts.hostname).replaceAll("\\.", "-").s,
+                    "./" + filename + "." + format);
+      }
 
-      var filePath = path.resolve(
-                      process.cwd(),
-                      outPath,
-                      S(urlParts.hostname).replaceAll("\\.", "-").s,
-                      "./" + filename + "." + format),
-      args = [captureScript, url, filePath, '--username', username,
+      var args = [captureScript, url, filePath, '--username', username,
         '--password', password, '--paper-orientation', paperOrientation,
         '--paper-margin', paperMargin, '--paper-format', paperFormat,
         '--viewport-width', viewportWidth, '--viewport-height', viewportHeight];

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ var MAX_PHANTOMJS_SPAWNS = 10,
 
 function capture(urls, options, callback) {
 
+  if (typeof urls === 'string') {
+    urls = new Array(urls);
+  }
+
   if (typeof options === 'function') {
     callback = options;
     options = {};
@@ -57,7 +61,7 @@ function capture(urls, options, callback) {
           filename = urlParts.pathname,
           auth = urlParts.auth,
           filePath;
-          
+
       // The outPath is a file, so don't generate the URLs automatically
       if ([".pdf", ".jpg", ".png", ".gif"].indexOf(outPath.substr(-4)) !== -1) {
         filePath = outPath;

--- a/phantomjs/capture.js
+++ b/phantomjs/capture.js
@@ -32,6 +32,10 @@ output = options.output;
 page.settings.userName = options.username || '';
 page.settings.password = options.password || '';
 
+// This fixes some weird bug on Windows where a large border is
+// displayed along the page.
+page.zoomFactor = 1.2;
+
 page.viewportSize = {
     width: options.viewportWidth || 1024,
     height: options.viewportHeight || 768,

--- a/test/capture.js
+++ b/test/capture.js
@@ -33,6 +33,13 @@ describe('capture', function() {
       });
     });
 
+    it('should capture screenshot of 1 page to a specific file', function(done) {
+      capture(['http://127.0.0.1:8899/'], { out: './test/tmp/screenshot.png' }, function(err) {
+        assert.ok(fs.statSync(path.join(__dirname, 'tmp/screenshot.png')).isFile());
+        done();
+      });
+    });
+
   });
 
   after(function(done) {
@@ -40,7 +47,7 @@ describe('capture', function() {
     wrench.rmdirSyncRecursive(temp);
     done();
   });
-  
+
 });
 
 

--- a/test/capture.js
+++ b/test/capture.js
@@ -40,6 +40,12 @@ describe('capture', function() {
       });
     });
 
+    it('should capture screenshot of 1 page specified as a string', function(done) {
+      capture('http://127.0.0.1:8899/', { out: './test/tmp' }, function(err) {
+        assert.ok(fs.statSync(path.join(__dirname, 'tmp/127-0-0-1/index.png')).isFile());
+        done();
+      });
+    });
   });
 
   after(function(done) {


### PR DESCRIPTION
Hey Mike,

I've added some extra flexibility for capturing single URLs:
- Specify the exact path for the screenshot, rather than have it generated.
- Allow to pass the URL as a string, rather than an array.

I've added tests for both these modification.
